### PR TITLE
Update for CPP 17

### DIFF
--- a/include/NamespaceAliases.hpp
+++ b/include/NamespaceAliases.hpp
@@ -20,6 +20,16 @@ limitations under the License.
 
 #pragma once
 
-#include <experimental/filesystem>
+// For C++ 17 and above use built in filesystem
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
 
+#include <filesystem>
+namespace fs = std::filesystem;
+
+#else
+
+#include <experimental/filesystem>
 namespace fs = std::experimental::filesystem::v1;
+
+#endif
+


### PR DESCRIPTION
Filesystem is built into c++ 17 libraries, so alias namespace to that if compiling for cpp 17 rather than using pre-17 deprecated experimental version